### PR TITLE
イージング修正

### DIFF
--- a/Assets/imgui.ini
+++ b/Assets/imgui.ini
@@ -34,7 +34,7 @@ Size=271,51
 Collapsed=0
 
 [Window][Create UIObject]
-Pos=374,290
+Pos=375,290
 Size=429,206
 Collapsed=0
 

--- a/Engine/DirectX/Easing.cpp
+++ b/Engine/DirectX/Easing.cpp
@@ -4,11 +4,15 @@
 #include<numbers>
 #include<cmath>
 #include<utility>
+#include"Direct3D.h"
 
-float Easing::GetValue(float v0, float v1, float ratio, Easing::TYPE type)
+float Easing::GetValue(float v0, float v1, float pile, Easing::TYPE type)
 {
-	auto func = GetCalcFunction(type);
-	return func(v0, v1, ratio);
+	auto func = Easing::GetCalcFunction(type);
+
+	double ratio = func(pile);
+
+	return (v0*ratio) + ((1-ratio) * v1);
 }
 
 Easing::Easing(float v0, float v1, float addRatio) :val0_(v0), val1_(v1), ratio_(addRatio), pile_(.0f), isStop(false)
@@ -27,79 +31,66 @@ float Easing::GetValue(Easing::TYPE type)
 	if(!isStop)	pile_ += ratio_;
 
 	Check(.0f, 1.0f, pile_);
-	return func(val0_, val1_, pile_);
+
+	double ratio = func(pile_);
+
+	return (ratio * val0_) + ((1 - ratio) * val1_);
 }
 
-
-float Easing::CalcStraight(float v0, float v1, float ratio)
+double Easing::CalcStraight(double t)
 {
-	Check(v0, v1, ratio);
-
-	float invRatio = 1 - ratio;
-
-	return ((ratio * v0) + (invRatio * v1));
+	return t;
 }
 
 std::string Easing::GetEnumName(Easing::TYPE t)
 {
+
 	switch (t)
 	{
-	case TYPE::STRAIGHT:return "Straight";
+    case TYPE::STRAIGHT: return "Straight";
+    case TYPE::IN_SINE: return "InSine";
+    case TYPE::OUT_SINE: return "OutSine";
+    case TYPE::IN_OUT_SINE: return "InOutSine";
+    case TYPE::IN_QUAD: return "InQuad";
+    case TYPE::OUT_QUAD: return "OutQuad";
+    case TYPE::IN_OUT_QUAD: return "InOutQuad";
+    case TYPE::IN_CUBIC: return "InCubic";
+    case TYPE::OUT_CUBIC: return "OutCubic";
+    case TYPE::IN_QUART: return "InQuart";
+    case TYPE::OUT_QUART: return "OutQuart";
+    case TYPE::IN_OUT_QUART: return "InOutQuart";
+    case TYPE::IN_QUINT: return "InQuint";
+    case TYPE::OUT_QUINT: return "OutQuint";
+    case TYPE::IN_OUT_QUINT: return "InOutQuint";
+    case TYPE::IN_EXPO: return "InExpo";
+    case TYPE::OUT_EXPO: return "OutExpo";
+    case TYPE::IN_OUT_EXPO: return "InOutExpo";
+    case TYPE::IN_CIRC: return "InCirc";
+    case TYPE::OUT_CIRC: return "OutCirc";
+    case TYPE::IN_OUT_CIRC: return "InOutCirc";
+    case TYPE::IN_BACK: return "InBack";
+    case TYPE::OUT_BACK: return "OutBack";
+    case TYPE::IN_OUT_BACK: return "InOutBack";
+    case TYPE::IN_ELASTIC: return "InElastic";
+    case TYPE::OUT_ELASTIC: return "OutElastic";
+    case TYPE::IN_OUT_ELASTIC: return "InOutElastic";
+    case TYPE::IN_BOUNCE: return "InBounce";
+    case TYPE::OUT_BOUNCE: return "OutBounce";
+    case TYPE::IN_OUT_BOUNCE: return "InOutBounce";
 
-	case TYPE::SIN:		return "Sin";
-
-	case TYPE::COS:		return "Cos";
-
-	case TYPE::EaseIO:	return "EaseIO";
-
-	default: return "None";
+	default: return "Error";
 	}
 }
 
-float Easing::CalsEaseIO(float v0, float v1, float ratio)
-{
-	Check(v0, v1, ratio);
-
-	ratio = .5f + (std::sin(std::numbers::pi * (ratio - 0.5))) * .5f;
-	float invRatio = 1 - ratio;
-
-	return ((ratio * v0) + (invRatio * v1));
-}
-
-float Easing::CalcSin(float v0, float v1, float ratio)
-{
-	Check(v0, v1, ratio);
-
-	ratio = std::sin((std::numbers::pi / 2) * ratio);
-	float invRatio = 1 - ratio;
-
-	return ((ratio * v0) + (invRatio * v1));
-}
-
-float Easing::CalcCos(float v0, float v1, float ratio)
-{
-	Check(v0, v1, ratio);
-
-	ratio =1- std::cos((std::numbers::pi / 2) * ratio);
-	float invRatio = 1 - ratio;
-
-	return ((ratio * v0) + (invRatio * v1));
-}
-
-float(*Easing::GetCalcFunction(Easing::TYPE type))(float, float, float)
+std::function<double(double)>(Easing::GetCalcFunction(Easing::TYPE type))
 {
 	switch (type)
 	{
 	case Easing::TYPE::STRAIGHT:	
-		return Easing::CalcStraight;
-	case Easing::TYPE::SIN:
-		return Easing::CalcSin;
-	case Easing::TYPE::COS:
-		return Easing::CalcCos;
-	case Easing::TYPE::EaseIO:
-		return Easing::CalsEaseIO;
+		return std::function<double(double)>(Easing::CalcStraight);
+		
+    default:
+        return (Direct3D::EaseFunc.at(GetEnumName(type)));
 
-	default:
-		return Easing::CalcStraight;
 	}
 }

--- a/Engine/DirectX/Easing.h
+++ b/Engine/DirectX/Easing.h
@@ -1,5 +1,6 @@
 #pragma once
 #include<string>
+#include<functional>
 
 class Easing
 {
@@ -8,16 +9,42 @@ public :
 	enum class TYPE
 	{
 		STRAIGHT,
-		SIN,
-		COS,
-		EaseIO,
+		IN_SINE,
+		OUT_SINE,
+		IN_OUT_SINE,
+		IN_QUAD,
+		OUT_QUAD,
+		IN_OUT_QUAD,
+		IN_CUBIC,
+		OUT_CUBIC,
+		IN_QUART,
+		OUT_QUART,
+		IN_OUT_QUART,
+		IN_QUINT,
+		OUT_QUINT,
+		IN_OUT_QUINT,
+		IN_EXPO,
+		OUT_EXPO,
+		IN_OUT_EXPO,
+		IN_CIRC,
+		OUT_CIRC,
+		IN_OUT_CIRC,
+		IN_BACK,
+		OUT_BACK,
+		IN_OUT_BACK,
+		IN_ELASTIC,
+		OUT_ELASTIC,
+		IN_OUT_ELASTIC,
+		IN_BOUNCE,
+		OUT_BOUNCE,
+		IN_OUT_BOUNCE,
 
 		AMOUNT
 	};
 
 	Easing(float v0,float v1,float addRatio);
 
-	static float GetValue(float v0, float v1, float ratio , Easing::TYPE type);
+	static float GetValue(float v0, float v1, float pile , Easing::TYPE type);
 	float GetValue(Easing::TYPE type);
 
 	float pile_;
@@ -28,13 +55,10 @@ public :
 
 	static std::string GetEnumName(Easing::TYPE t);
 
+	static double CalcStraight(double t);
+
 private:
 
-	static float CalcStraight(float v0, float v1, float ratio);
-	static float CalcSin(float v0, float v1, float ratio);
-	static float CalcCos(float v0, float v1, float ratio);
-	static float CalsEaseIO(float v0, float v1, float ratio);
-
-	static float (*GetCalcFunction(Easing::TYPE type))(float, float, float);
+	static std::function<double(double)>(GetCalcFunction(Easing::TYPE type));
 };
 

--- a/Game/Objects/UI/Components/Component_UIEasing.cpp
+++ b/Game/Objects/UI/Components/Component_UIEasing.cpp
@@ -1,6 +1,6 @@
 #include "Component_UIEasing.h"
 
-Component_UIEasing::Component_UIEasing(UIObject* p) :easing_(0, 0, 0),p_ui(p),easing_type(Easing::TYPE::COS)
+Component_UIEasing::Component_UIEasing(UIObject* p) :easing_(0, 0, 0),p_ui(p),easing_type(Easing::TYPE::STRAIGHT)
 {
 }
 
@@ -24,7 +24,6 @@ void Component_UIEasing::Save(json& _saveObj)
 		_saveObj["Easing_Start"] =  easing_.val0_ ;
 		_saveObj["Easing_Goal"] =  easing_.val1_ ;
 		_saveObj["Easing_Ratio"] =  easing_.ratio_ ;
-		_saveObj["Easing_Pile"] =  easing_.pile_ ;
 		_saveObj["Easing_Type"] =  static_cast<int>(this->easing_type ) ;
 	}
 }
@@ -59,7 +58,6 @@ void Component_UIEasing::Load(json& _loadObj)
 		SetFloat("Easing_Start", e.val0_);
 		SetFloat("Easing_Goal", e.val1_);
 		SetFloat("Easing_Ratio", e.ratio_);
-		SetFloat("Easing_Pile",e.pile_);
 
 		int temp = NULL;
 		SetInt("Easing_Type",temp);

--- a/Game/Objects/UI/UIObject.cpp
+++ b/Game/Objects/UI/UIObject.cpp
@@ -134,9 +134,9 @@ void UIObject::ChildDrawData()
 		if (ImGui::TreeNode("Easing Data")) {
 			auto& eas = *easing_.get();
 
-			ImGui::DragFloat3("2nd Pos", &eas.secTransform_.position_.x, 0.1f);
-			ImGui::DragFloat3("2nd Rot", &eas.secTransform_.rotate_.x, 0.1f);
-			ImGui::DragFloat3("2nd Scale", &eas.secTransform_.scale_.x, 0.1f);
+			ImGui::DragFloat3("End Pos", &eas.secTransform_.position_.x, 0.1f);
+			ImGui::DragFloat3("End Rot", &eas.secTransform_.rotate_.x, 0.1f);
+			ImGui::DragFloat3("End Scale", &eas.secTransform_.scale_.x, 0.1f);
 
 			ImGui::DragFloat("Ratio now", &eas.GetEasing()->pile_, 0.005f,.0f,1.0f);
 			ImGui::DragFloat("Ratio/Frame", &eas.GetEasing()->ratio_, 0.005f ,-1.0f,1.0f);
@@ -145,9 +145,17 @@ void UIObject::ChildDrawData()
 
 			auto settable_in_Line = 4u;
 
-			for (auto i = 0u; i < static_cast<int>(Easing::TYPE::AMOUNT); i++) {
-				ImGui::RadioButton(Easing::GetEnumName(static_cast<Easing::TYPE>(i)).c_str(), reinterpret_cast<int*>(&eas.easing_type), i);	
-				if((i < static_cast<int>(Easing::TYPE::AMOUNT) -1) && (i+1)%settable_in_Line)ImGui::SameLine();
+			if (ImGui::BeginCombo(": Easing Type", Easing::GetEnumName(easing_.get()->easing_type).c_str()))
+			{
+				for (auto i = 0u; i < static_cast<int>(Easing::TYPE::AMOUNT); i++) {
+
+					if (ImGui::Selectable(Easing::GetEnumName(static_cast<Easing::TYPE>(i)).c_str(), easing_.get()->easing_type == static_cast<Easing::TYPE>(i)))
+					{
+						easing_.get()->easing_type = static_cast<Easing::TYPE>(i);
+					}
+				}
+
+				ImGui::EndCombo();
 			}
 			ImGui::TreePop();
 		}

--- a/Game/Otheres/GameEditor.cpp
+++ b/Game/Otheres/GameEditor.cpp
@@ -285,13 +285,13 @@ void GameEditor::UIObjectCreateWindow()
 			ImGui::Separator();
 
 			// 名前を入力
-			ImGui::InputTextWithHint(":seting name", "Input object name...", nameBuffer, IM_ARRAYSIZE(nameBuffer));
+			ImGui::InputTextWithHint(":setting name", "Input object name...", nameBuffer, IM_ARRAYSIZE(nameBuffer));
 
 			// タイプを選択
 			static UIType uitype = UIType::UI_NONE;	// 初期選択項目
 			static std::string type = "NONE";		// 初期選択項目
 
-			if (ImGui::BeginCombo(":seting type", type.c_str())) {
+			if (ImGui::BeginCombo(":setting type", type.c_str())) {
 				for (int i = 0; i < UIType::UI_MAX; i++) {
 					std::string uiTypeString = UIObject::GetUITypeString((UIType)i);
 					if (uiTypeString.empty()) continue; // 空文字列を無視


### PR DESCRIPTION
GameEditorの一部スペルミス修正
関数オブジェクトを使用しいろいろなイージングが選択可能に
現在のイージング割合のセーブを廃止。毎回0からなるように
DrawDataで、Selectableを使用したイージングタイプの選択に変更