### PR TITLE
改良：アクセサリーコンポーネントの追加、その他修正追加

### DIFF
--- a/Engine/GameObject/GameObject.h
+++ b/Engine/GameObject/GameObject.h
@@ -134,6 +134,7 @@ public:
 	//RootJobを取得
 	GameObject* GetRootJob();
 
+	inline Transform GetTransform() { return this->transform_; };
 
 	//各アクセス関数
 	XMFLOAT3 GetPosition() { return transform_.position_; }

--- a/Engine/ResourceManager/Model.cpp
+++ b/Engine/ResourceManager/Model.cpp
@@ -89,6 +89,11 @@ namespace Model
 		}
 	}
 
+	std::string GetModelName(int handle)
+	{
+		return _datas[handle]->fileName;
+	}
+
 
 	//”CˆÓ‚Ìƒ‚ƒfƒ‹‚ðŠJ•ú
 	void Release(int handle)

--- a/Engine/ResourceManager/Model.cpp
+++ b/Engine/ResourceManager/Model.cpp
@@ -158,30 +158,12 @@ namespace Model
 	XMFLOAT3 GetBonePosition(int handle, std::string boneName)
 	{
 		XMFLOAT3 pos = _datas[handle]->pFbx->GetBonePosition(boneName, static_cast<int>(_datas[handle]->nowFrame));
-		XMVECTOR vec = XMVector3TransformCoord(XMLoadFloat3(&pos), _datas[handle]->transform.GetWorldMatrix());
-		XMStoreFloat3(&pos, vec);
 		return pos;
 	}
 
-	XMFLOAT3 GetBoneRotation(int handle, std::string boneName, XMFLOAT3 parentRotation)
+	XMFLOAT3 GetBoneRotation(int handle, std::string boneName)
 	{
 		auto mat = _datas[handle]->pFbx->GetBoneRotationMatrix(boneName, static_cast<int>(_datas[handle]->nowFrame));
-
-		{
-			/*
-			ˆÈ‰º‚Ì•û–@‚Åƒ[ƒ‹ƒh‰ñ“]‚ðŽæ“¾‚µ‡¬‚·‚é‚Æ
-			­‚µ‰ñ“]‚ª‚¨‚©‚µ‚­‚È‚é‚½‚ß”pŽ~
-			*/
-			//XMVECTOR vecRot = {};
-			//XMVECTOR dummy = {};
-
-			//XMMatrixDecompose(&dummy, &vecRot, &dummy, _datas[handle]->transform.GetWorldMatrix());
-
-			//auto matW = XMMatrixRotationQuaternion(vecRot);
-
-			//mat = mat * matW;
-
-		}
 
 		XMFLOAT3 rotation = {};
 
@@ -198,9 +180,9 @@ namespace Model
 		yaw = std::atan2(m21, m11);   
 		roll = std::atan2(m32, m33); 
 
-		rotation.x = XMConvertToDegrees(roll) + parentRotation.x;
-		rotation.y = XMConvertToDegrees(pitch) + parentRotation.y;
-		rotation.z = XMConvertToDegrees(yaw) + parentRotation.z;
+		rotation.x = XMConvertToDegrees(roll);
+		rotation.y = XMConvertToDegrees(pitch);
+		rotation.z = XMConvertToDegrees(yaw);
 		
 		return rotation;
 	}
@@ -214,10 +196,6 @@ namespace Model
 			XMVECTOR dummy = {};
 
 			XMMatrixDecompose(&vecScale, &dummy, &dummy, _datas[handle]->transform.GetWorldMatrix());
-
-			scale.x *= XMVectorGetX(vecScale);
-			scale.y *= XMVectorGetY(vecScale);
-			scale.z *= XMVectorGetZ(vecScale);
 		}
 
 		return scale;

--- a/Engine/ResourceManager/Model.h
+++ b/Engine/ResourceManager/Model.h
@@ -83,17 +83,9 @@ namespace Model
 	//任意のボーンの位置を取得
 	//引数：handle		調べたいモデルの番号
 	//引数：boneName	調べたいボーンの名前
-	//戻値：ボーンの位置（ワールド座標）
+	//戻値：ボーンの位置（ローカル座標）
 	XMFLOAT3 GetBonePosition(int handle, std::string boneName);
-
-	/// <summary>
-	/// この関数のみ技術的な問題で親の回転(グローバル)が必要
-	/// </summary>
-	/// <param name="handle"></param>
-	/// <param name="boneName"></param>
-	/// <param name="parentRotation"></param>
-	/// <returns></returns>
-	XMFLOAT3 GetBoneRotation(int handle, std::string boneName,XMFLOAT3 parentRotation);
+	XMFLOAT3 GetBoneRotation(int handle, std::string boneName);
 	XMFLOAT3 GetBoneScale(int handle, std::string boneName);
 
 	//ワールド行列を設定

--- a/Engine/ResourceManager/Model.h
+++ b/Engine/ResourceManager/Model.h
@@ -60,6 +60,8 @@ namespace Model
 	//引数：matrix	ワールド行列
 	void Draw(int handle);
 
+	std::string GetModelName(int handle);
+
 	//任意のモデルを開放
 	//引数：handle	開放したいモデルの番号
 	void Release(int handle);

--- a/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
+++ b/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
@@ -236,7 +236,7 @@ void Component_PlayerBehavior::DrawData()
 {
 	// 高さの設定
 	ImGui::DragFloat("ShootHeight", &shootHeight_, 0.1f);
-
+	
 	// 無敵フレームの設定
 	ImGui::DragInt("invincibilityFrame", &invincibilityFrame_, 1);
 }

--- a/Game/Objects/Stage/Components/Component.cpp
+++ b/Game/Objects/Stage/Components/Component.cpp
@@ -31,6 +31,7 @@
 #include "PlantComponents/Component_PlantGenerator.h"
 #include "PlantComponents/Component_Plant.h"
 #include "GaugeComponents/Component_StaminaGauge.h"
+#include "MotionComponent/Component_Accessory.h"
 
 Component::Component(StageObject* _holder, string _name,ComponentType _type)
     :holder_(_holder), name_(_name),type_(_type),childComponents_(),parent_(nullptr),isActive_(false)
@@ -237,6 +238,7 @@ Component* CreateComponent(string _name, ComponentType _type, StageObject* _hold
 	    	case PlantGenerator: comp = new Component_PlantGenerator(_name, _holder, _parent); break;
        	case Plant: comp = new Component_Plant(_name, _holder, _parent); break;
 		    case StaminaGauge: comp = new Component_StaminaGauge(_name, _holder, _parent); break;
+			case Accessory: comp = new Component_Accessory(_name, _holder, _parent); break;
         default: /* その他コンポーネントを追加する時は上記のように追加 */ break;
     }
     return comp;
@@ -277,6 +279,7 @@ string ComponentTypeToString(ComponentType _type)
 	case PlantGenerator: return "PlantGeneratorComponent";
 	case Plant: return "PlantComponent";
 	case StaminaGauge: return "StaminaGaugeComponent";
+	case Accessory: return "AccessoryComponent";
 		// その他コンポーネントを追加する時は上記のように追加
 
 	default: return "None";

--- a/Game/Objects/Stage/Components/Component.h
+++ b/Game/Objects/Stage/Components/Component.h
@@ -41,6 +41,7 @@ enum ComponentType
 	PlantGenerator,
 	Plant,
 	StaminaGauge, 
+	Accessory,
 	// コンポーネント追加時に識別番号を追加
 	Max
 	

--- a/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.cpp
+++ b/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.cpp
@@ -128,23 +128,23 @@ void Component_Accessory::ExchangeModel(std::string filePath)
 
 void Component_Accessory::Load(json& _loadObj)
 {
-	if (_loadObj.contains("ModelPath")) gunModelHandle_ = Model::Load(_loadObj["ModelPath"]);
+	if (_loadObj.contains("Accessory ModelPath")) gunModelHandle_ = Model::Load(_loadObj["ModelPath"]);
 
-	if (_loadObj.contains("Original Position")) originalPosition_
-		={ _loadObj["Original Position"][0],_loadObj["Original Position"][1],_loadObj["Original Position"][2] };
-	if (_loadObj.contains("Original Rotate")) originalRotate_
-		= { _loadObj["Original Rotate"][0],_loadObj["Original Rotate"][1],_loadObj["Original Rotate"][2] };
-	if (_loadObj.contains("Original Scale"))originalScale_
-		= { _loadObj["Original Scale"][0],_loadObj["Original Scale"][1],_loadObj["Original Scale"][2] };
+	if (_loadObj.contains("Accessory Original Position")) originalPosition_
+		={ _loadObj["Accessory Original Position"][0],_loadObj["Original Position"][1],_loadObj["Original Position"][2] };
+	if (_loadObj.contains("Accessory Original Rotate")) originalRotate_
+		= { _loadObj["Accessory Original Rotate"][0],_loadObj["Original Rotate"][1],_loadObj["Original Rotate"][2] };
+	if (_loadObj.contains("Accessory Original Scale"))originalScale_
+		= { _loadObj["Accessory Original Scale"][0],_loadObj["Original Scale"][1],_loadObj["Original Scale"][2] };
 
 	ExchangeModel(_loadObj["ModelPath"]);
 }
 
 void Component_Accessory::Save(json& _saveObj)
 {
-	_saveObj["ModelPath"] = Model::GetModelName(gunModelHandle_);
+	_saveObj["Accessory ModelPath"] = Model::GetModelName(gunModelHandle_);
 
-	_saveObj["Original Position"] = { originalPosition_.x,originalPosition_.y,originalPosition_.z };
-	_saveObj["Original Rotate"] = { originalRotate_.x,originalRotate_.y,originalRotate_.z };
-	_saveObj["Original Scale"] = { originalScale_.x,originalScale_.y,originalScale_.z };
+	_saveObj["Accessory Original Position"] = { originalPosition_.x,originalPosition_.y,originalPosition_.z };
+	_saveObj["Accessory Original Rotate"] = { originalRotate_.x,originalRotate_.y,originalRotate_.z };
+	_saveObj["Accessory Original Scale"] = { originalScale_.x,originalScale_.y,originalScale_.z };
 }

--- a/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.cpp
+++ b/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.cpp
@@ -40,7 +40,7 @@ void Component_Accessory::Initialize()
 			// ディレクトリを戻す
 			SetCurrentDirectory(defaultCurrentDir);
 
-			gun_ = CreateStageObject("Player's gun", path, holder_->GetRootJob());
+			gun_ = CreateStageObject("Player's gun", path, holder_);
 
 		}
 	}
@@ -53,7 +53,7 @@ void Component_Accessory::Update()
 	Model::SetTransform(playerHandle, transform);
 
 	auto bonePos = Model::GetBonePosition(playerHandle, bone_);
-	auto boneRot = Model::GetBoneRotation(playerHandle, bone_,holder_->GetRotate());
+	auto boneRot = Model::GetBoneRotation(playerHandle, bone_);
 	auto boneScale = Model::GetBoneScale(playerHandle, bone_);
 
 	gun_->SetPosition(bonePos + originalPosition_);

--- a/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.cpp
+++ b/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.cpp
@@ -1,0 +1,150 @@
+#include "Component_Accessory.h"
+#include "../../../Engine/ImGui/imgui.h"
+#include "../../../Engine/Global.h"
+
+Component_Accessory::Component_Accessory(string _name, StageObject* _holder, Component* _parent)
+	:Component_Motion(_name, _holder, PlayerMotion, _parent), originalPosition_{}, originalRotate_{}, originalScale_{1,1,1},
+	gun_{}, gunModelHandle_{},bone_{ "mixamorig:LeftHand" }
+{
+}
+
+void Component_Accessory::Initialize()
+{
+	char defaultCurrentDir[MAX_PATH];
+	GetCurrentDirectory(MAX_PATH, defaultCurrentDir);
+	{
+		OPENFILENAME ofn; {
+			TCHAR szFile[MAX_PATH] = {}; // ファイル名を格納するバッファ
+			ZeroMemory(&ofn, sizeof(ofn)); // 構造体の初期化
+			ofn.lStructSize = sizeof(ofn); // 構造体のサイズ
+			ofn.lpstrFile = szFile; // ファイル名を格納するバッファ
+			ofn.lpstrFile[0] = '\0'; // 初期化
+			ofn.nMaxFile = sizeof(szFile); // ファイル名バッファのサイズ
+			ofn.lpstrFilter = TEXT("FBXファイル(*.fbx)\0*.fbx\0すべてのファイル(*.*)\0*.*\0");
+			ofn.nFilterIndex = 1; // 初期選択するフィルター
+			ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST; // フラグ（ファイルが存在すること、パスが存在することを確認）
+			ofn.lpstrInitialDir = TEXT("."); // カレントディレクトリを初期選択位置として設定
+		}
+
+		// ファイルを選択するダイアログの表示
+		if (GetOpenFileName(&ofn) == TRUE) {
+			// ファイルパスを取得
+			string path = ofn.lpstrFile;
+
+			// カレントディレクトリからの相対パスを取得
+			path = FileManager::GetAssetsRelativePath(path);
+
+			// 文字列内の"\\"を"/"に置換
+			FileManager::ReplaceBackslashes(path);
+
+			// ディレクトリを戻す
+			SetCurrentDirectory(defaultCurrentDir);
+
+			gun_ = CreateStageObject("Player's gun", path, holder_->GetRootJob());
+
+		}
+	}
+}
+
+void Component_Accessory::Update()
+{
+	auto playerHandle = holder_->GetModelHandle();
+	auto transform = holder_->GetTransform();
+	Model::SetTransform(playerHandle, transform);
+
+	auto bonePos = Model::GetBonePosition(playerHandle, bone_);
+	auto boneRot = Model::GetBoneRotation(playerHandle, bone_,holder_->GetRotate());
+	auto boneScale = Model::GetBoneScale(playerHandle, bone_);
+
+	gun_->SetPosition(bonePos + originalPosition_);
+	gun_->SetRotate(boneRot + originalRotate_);
+	gun_->SetScale({ boneScale.x * originalScale_.x ,boneScale.y * originalScale_.y,boneScale.z * originalScale_.z });
+}
+
+void Component_Accessory::Release()
+{
+	
+}
+
+void Component_Accessory::DrawData()
+{
+	ImGui::DragFloat3("Original Position", &originalPosition_.x, .01f);
+	ImGui::DragFloat3("Original Rotation", &originalRotate_.x, 1.f);
+	ImGui::DragFloat3("Original Scale", &originalScale_.x, .01f);
+	
+	if (ImGui::Button("Load Model")) {
+		//現在のカレントディレクトリを覚えておく
+		char defaultCurrentDir[MAX_PATH];
+		GetCurrentDirectory(MAX_PATH, defaultCurrentDir);
+		{
+			OPENFILENAME ofn; {
+				TCHAR szFile[MAX_PATH] = {}; // ファイル名を格納するバッファ
+				ZeroMemory(&ofn, sizeof(ofn)); // 構造体の初期化
+				ofn.lStructSize = sizeof(ofn); // 構造体のサイズ
+				ofn.lpstrFile = szFile; // ファイル名を格納するバッファ
+				ofn.lpstrFile[0] = '\0'; // 初期化
+				ofn.nMaxFile = sizeof(szFile); // ファイル名バッファのサイズ
+				ofn.lpstrFilter = TEXT("FBXファイル(*.fbx)\0*.fbx\0すべてのファイル(*.*)\0*.*\0"); 
+				ofn.nFilterIndex = 1; // 初期選択するフィルター
+				ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST; // フラグ（ファイルが存在すること、パスが存在することを確認）
+				ofn.lpstrInitialDir = TEXT("."); // カレントディレクトリを初期選択位置として設定
+			}
+
+			// ファイルを選択するダイアログの表示
+			if (GetOpenFileName(&ofn) == TRUE) {
+				// ファイルパスを取得
+				string path = ofn.lpstrFile;
+
+				// カレントディレクトリからの相対パスを取得
+				path = FileManager::GetAssetsRelativePath(path);
+
+				// 文字列内の"\\"を"/"に置換
+				FileManager::ReplaceBackslashes(path);
+
+				// ディレクトリを戻す
+				SetCurrentDirectory(defaultCurrentDir);
+
+				ExchangeModel(path);
+			}
+			else {
+				return;
+			}
+		}
+	}
+
+	ImGui::SameLine();
+	ImGui::Text(Model::GetModelName(gunModelHandle_).c_str());
+	ImGui::InputText(": Bone Name", bone_, sizeof(bone_));
+}
+
+void Component_Accessory::ExchangeModel(std::string filePath)
+{
+	gunModelHandle_ = Model::Load(filePath);
+
+	gun_->SetModelFilePath(filePath);
+	gun_->SetModelHandle(gunModelHandle_);
+}
+
+
+void Component_Accessory::Load(json& _loadObj)
+{
+	if (_loadObj.contains("ModelPath")) gunModelHandle_ = Model::Load(_loadObj["ModelPath"]);
+
+	if (_loadObj.contains("Original Position")) originalPosition_
+		={ _loadObj["Original Position"][0],_loadObj["Original Position"][1],_loadObj["Original Position"][2] };
+	if (_loadObj.contains("Original Rotate")) originalRotate_
+		= { _loadObj["Original Rotate"][0],_loadObj["Original Rotate"][1],_loadObj["Original Rotate"][2] };
+	if (_loadObj.contains("Original Scale"))originalScale_
+		= { _loadObj["Original Scale"][0],_loadObj["Original Scale"][1],_loadObj["Original Scale"][2] };
+
+	ExchangeModel(_loadObj["ModelPath"]);
+}
+
+void Component_Accessory::Save(json& _saveObj)
+{
+	_saveObj["ModelPath"] = Model::GetModelName(gunModelHandle_);
+
+	_saveObj["Original Position"] = { originalPosition_.x,originalPosition_.y,originalPosition_.z };
+	_saveObj["Original Rotate"] = { originalRotate_.x,originalRotate_.y,originalRotate_.z };
+	_saveObj["Original Scale"] = { originalScale_.x,originalScale_.y,originalScale_.z };
+}

--- a/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.h
+++ b/Game/Objects/Stage/Components/MotionComponent/Component_Accessory.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "Component_Motion.h"
+#include <vector>
+#include "../../Components/BehaviorComponents/Component_PlayerBehavior.h"
+
+class Component_Accessory : public Component_Motion
+{
+public:
+	/// <summary> コンストラクタ </summary>
+	Component_Accessory(string _name, StageObject* _holder, Component* _parent);
+
+	/// <summary> 初期化 </summary>
+	void Initialize() override;
+
+	/// <summary> 更新 </summary>
+	void Update() override;
+
+	/// <summary> 解放 </summary>
+	void Release() override;
+
+	/// <summary> ImGuiパネル表示 </summary>
+	void DrawData() override;
+
+	void ExchangeModel(std::string filePath);
+
+	void Load(json& _loadObj);
+	void Save(json& _saveObj);
+
+	char bone_[256];
+
+protected:
+	StageObject* gun_;
+	int gunModelHandle_;
+
+	XMFLOAT3 originalRotate_;
+	XMFLOAT3 originalScale_;
+	XMFLOAT3 originalPosition_;
+
+};
+

--- a/GameBaseDx11.vcxproj
+++ b/GameBaseDx11.vcxproj
@@ -139,6 +139,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Game\Objects\Stage\Components\MotionComponent\Component_Accessory.cpp" />
     <ClCompile Include="Game\Objects\Stage\Components\PlantComponents\Component_Plant.cpp" />
     <ClCompile Include="Game\Objects\Stage\Components\GaugeComponents\Component_StaminaGauge.cpp" />
     <ClCompile Include="Game\Objects\Stage\Components\PlantComponents\Component_PlantGenerator.cpp" />
@@ -233,6 +234,7 @@
     <ClCompile Include="Game\Objects\UI\UIProgressCircle.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Game\Objects\Stage\Components\MotionComponent\Component_Accessory.h" />
     <ClInclude Include="Game\Objects\Stage\Components\PlantComponents\Component_Plant.h" />
     <ClInclude Include="Game\Objects\Stage\Components\PlantComponents\Component_PlantGenerator.h" />
     <ClInclude Include="Game\Objects\Stage\Components\GaugeComponents\Component_StaminaGauge.h" />

--- a/GameBaseDx11.vcxproj.filters
+++ b/GameBaseDx11.vcxproj.filters
@@ -309,6 +309,7 @@
     <ClCompile Include="Game\Plants\PlantCollection.cpp" />
     <ClCompile Include="Game\Objects\Stage\Components\PlantComponents\Component_PlantGenerator.cpp" />
     <ClCompile Include="Game\Objects\UI\UIProgressCircle.cpp" />
+    <ClCompile Include="Game\Objects\Stage\Components\MotionComponent\Component_Accessory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Engine\Collider\BoxCollider.h">
@@ -545,6 +546,7 @@
     <ClInclude Include="Game\Objects\Stage\Components\PlantComponents\Component_PlantGenerator.h" />
     <ClInclude Include="Game\Plants\PlantCollection.h" />
     <ClInclude Include="Game\Objects\UI\UIProgressCircle.h" />
+    <ClInclude Include="Game\Objects\Stage\Components\MotionComponent\Component_Accessory.h" />
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Assets\Shader\Simple2D.hlsl">


### PR DESCRIPTION
Modelにhandleから名前を取得する関数の追加
Transform自体を取得できる関数をGameObjectに追加
Componentからアクセサリーコンポーネントを生成できるように
GetBonePosition,Rotation,Scaleの取得情報を、グローバルからローカルに変更

アクセサリーコンポーネントの追加
・ボーンを指定すると、そのコンポーネントのホルダーのアニメーション時の情報を得られる。
・Pos,Rot,Scaleがあり、改良したため問題なく操作可能。
・モデルの読み込みを適宜変更可能。Release時ならばExchangeModel関数を使えば変更可能。