### PR TITLE
UICursor　マウスとゲームパッド両方でカーソル位置を決定可能

### DIFF
--- a/Engine/Main.cpp
+++ b/Engine/Main.cpp
@@ -20,6 +20,7 @@
 #include "../Game/Otheres/AudioController.h"
 #include "ResourceManager/VFX.h"
 #include "ResourceManager/Transition.h"
+#include "../Game/Objects/UI/UICursor.h"
 
 // effekseerのヘッダーをインクルード
 
@@ -159,6 +160,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 				//入力（キーボード、マウス、コントローラー）情報を更新
 				Input::Update();
+				UICursor::Update();
 
 				if (Input::IsKeyDown(DIK_F4)) {
 					// 画面表示切替

--- a/Game/Objects/UI/UICursor.cpp
+++ b/Game/Objects/UI/UICursor.cpp
@@ -1,0 +1,73 @@
+#include "UICursor.h"
+#include "../../../Engine/DirectX/Input.h"
+#include "../../../Engine/Global.h"
+#include "../../../Engine/ImGui/imgui.h"
+
+namespace UICursor
+{
+	XMFLOAT2 position_ = { Direct3D::screenWidth_ / 2.f, Direct3D::screenHeight_ / 2.f };
+	bool isHide_ = false;
+	XMFLOAT2 sensitivityPad_ = { 10.f,10.f };
+	XMFLOAT2 sensitivityMouse_ = { 1.f,1.f };
+
+	DirectX::XMFLOAT2 GetPosition()
+	{
+		return position_;
+	}
+
+	void SetPosition(DirectX::XMFLOAT2 pos)
+	{
+		position_ = pos;
+	}
+
+	void Update()
+	{
+		SetCursorPos(position_.x, position_.y);
+
+		if (isHide_)	return;
+
+		auto vecCursor = Input::GetMouseMove();
+		position_ =
+		{
+			position_.x + (vecCursor.x*sensitivityMouse_.x) ,
+			position_.y + (vecCursor.y*sensitivityMouse_.y) 
+		};
+
+		vecCursor = Input::GetPadStickL(0);
+		position_ =
+		{
+			position_.x + (vecCursor.x * sensitivityPad_.x) ,
+			position_.y + (-vecCursor.y * sensitivityPad_.y)
+		};
+	}
+
+	bool IsHide()
+	{
+		return isHide_;
+	}
+
+	void ToHide(bool isHide)
+	{
+		isHide_ = isHide;
+		ShowCursor(!isHide_);
+	}
+
+	void SetSensitivity_Mouse(DirectX::XMFLOAT2 sens)
+	{
+		sensitivityMouse_ = sens;
+	}
+
+	void SetSensitivity_Pad(DirectX::XMFLOAT2 sens)
+	{
+		sensitivityPad_ = sens;
+	}
+
+	DirectX::XMFLOAT2 GetSensitivity_Mouse()
+	{
+		return sensitivityMouse_;
+	}
+	DirectX::XMFLOAT2 GetSensitivity_Pad()
+	{
+		return sensitivityPad_;
+	}
+}

--- a/Game/Objects/UI/UICursor.h
+++ b/Game/Objects/UI/UICursor.h
@@ -1,0 +1,21 @@
+#pragma once
+#include"DirectXMath.h"
+
+namespace UICursor
+{
+
+	DirectX::XMFLOAT2 GetPosition();
+	void SetPosition(DirectX::XMFLOAT2 pos);
+
+	void Update();
+
+	bool IsHide();
+	void ToHide(bool isHide);
+
+	void SetSensitivity_Mouse(DirectX::XMFLOAT2 sens);
+	void SetSensitivity_Pad(DirectX::XMFLOAT2 sens);
+
+	DirectX::XMFLOAT2 GetSensitivity_Mouse();
+	DirectX::XMFLOAT2 GetSensitivity_Pad();
+};
+

--- a/Game/Scenes/Scene_Play.cpp
+++ b/Game/Scenes/Scene_Play.cpp
@@ -19,12 +19,14 @@
 #include "../Objects/UI/UIProgressBar.h"
 #include "../Objects/Stage/Components/GaugeComponents/Component_StaminaGauge.h"
 #include "../Objects/UI/UIProgressCircle.h"
+#include "../../Game/Objects/UI/UICursor.h"
 
 using namespace Constants;
 
 Scene_Play::Scene_Play(GameObject* parent)
 	:GameObject(parent, "Scene_Play"), pStage_(nullptr), tpsCamera_(nullptr), fixedCursorPos(true), cursorVisible(true), isGameStart_(false), isBossSpawn_(false)
 {
+	UICursor::ToHide(true);
 }
 
 void Scene_Play::Initialize()
@@ -39,7 +41,6 @@ void Scene_Play::Initialize()
 	InitCamera();
 
 	// カーソルの非表示化
-	ShowCursor(false);
 }
 
 void Scene_Play::Update()
@@ -198,7 +199,7 @@ void Scene_Play::SetCursorMode()
 
 		// カーソルの表示状態を切り替える
 		cursorVisible = !fixedCursorPos;
-		ShowCursor(cursorVisible);
+		UICursor::ToHide(!cursorVisible);
 	}
 
 	// カーソルの位置を中央に固定

--- a/GameBaseDx11.vcxproj
+++ b/GameBaseDx11.vcxproj
@@ -235,6 +235,7 @@
     <ClCompile Include="Game\Objects\UI\UIInputString.cpp" />
     <ClCompile Include="Game\Plants\PlantCollection.cpp" />
     <ClCompile Include="Game\Objects\UI\UIProgressCircle.cpp" />
+    <ClCompile Include="Game\Objects\UI\UICursor.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Game\Objects\Stage\Components\BehaviorComponents\Component_RangeEnemyBehavior.h" />
@@ -336,6 +337,7 @@
     <ClInclude Include="Game\Objects\UI\UIInputString.h" />
     <ClInclude Include="Game\Plants\PlantCollection.h" />
     <ClInclude Include="Game\Objects\UI\UIProgressCircle.h" />
+    <ClInclude Include="Game\Objects\UI\UICursor.h" />
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Assets\Shader\BillBoard.hlsl">


### PR DESCRIPTION
カーソル位置をコントローターのいだりとりがーで変更可能に。またtoHide関数を経由し非表示も可能になったため、Scene_Playを一部書き替えた。 UICursorはInputのupdate直後にUpdateされる
感度はパッドとマウス、xyで別々