### PR TITLE
Player内のTPSCameraの壁めり込みの防止

### DIFF
--- a/Assets/imgui.ini
+++ b/Assets/imgui.ini
@@ -1,5 +1,5 @@
 [Window][Debug##Default]
-Pos=1155,57
+Pos=813,101
 Size=313,103
 Collapsed=0
 

--- a/Game/Objects/Camera/TPSCamera.cpp
+++ b/Game/Objects/Camera/TPSCamera.cpp
@@ -133,7 +133,7 @@ void TPSCamera::CalcRotateAngle(XMFLOAT3 _mouseMove, XMFLOAT3 _padMove)
 	if (angle_.x > ROTATE_LOWER_LIMIT)angle_.x -= _mouseMove.y * sensitivity_;
 }
 
-void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3& _camaraTarget)
+void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3& _cameraTarget)
 {
     // 回転の中心を設定
     XMFLOAT3 center = pTarget_->GetPosition();
@@ -154,7 +154,7 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
 
         // 原点からの位置を求めて、カメラの焦点を設定
         XMVECTOR origin_To_camTarget = XMLoadFloat3(&center) + center_To_camTarget;
-        XMStoreFloat3(&_camaraTarget, origin_To_camTarget);
+        XMStoreFloat3(&_cameraTarget, origin_To_camTarget);
 
         // center_To_camTargetの逆ベクトルを用意
         XMVECTOR center_To_camPosition = -center_To_camTarget;
@@ -170,7 +170,7 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
     // ｘ軸の回転を行う
     {
         // 中心を移動
-        XMVECTOR newCenter = (XMLoadFloat3(&_cameraPosition) + XMLoadFloat3(&_camaraTarget)) * ROTATE_Y;
+        XMVECTOR newCenter = (XMLoadFloat3(&_cameraPosition) + XMLoadFloat3(&_cameraTarget)) * ROTATE_Y;
         XMFLOAT3 prevCenter = center;
         XMStoreFloat3(&center, newCenter);
 
@@ -183,10 +183,10 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
         XMMATRIX rotateAxis = XMMatrixRotationAxis(axis, XMConvertToRadians(angle_.x));
 
         //　焦点を設定 
-        XMVECTOR newCenter_To_camTarget = XMLoadFloat3(&_camaraTarget) - XMLoadFloat3(&center);
+        XMVECTOR newCenter_To_camTarget = XMLoadFloat3(&_cameraTarget) - XMLoadFloat3(&center);
         newCenter_To_camTarget = XMVector3Transform(newCenter_To_camTarget, rotateAxis);
         XMVECTOR origin_To_camTarget = XMLoadFloat3(&center) + newCenter_To_camTarget;
-        XMStoreFloat3(&_camaraTarget, origin_To_camTarget);
+        XMStoreFloat3(&_cameraTarget, origin_To_camTarget);
 
         // 位置を設定
         XMVECTOR newCenter_To_camPosition = -newCenter_To_camTarget;
@@ -197,19 +197,24 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
 
     float rayCastDir = targetDistance_;;
 
-    RayCastData rayCast = {};
-    {
-        auto tTOp = _cameraPosition- _camaraTarget  ;
-        auto tTOpvec = XMLoadFloat3(&tTOp);
-        XMStoreFloat3(&rayCast.dir, XMVector3Normalize(tTOpvec));
-        rayCast.start = _camaraTarget;
-    }
-
     for (auto itr : hModels_) {
-        Model::RayCast(itr, &rayCast);
 
+        RayCastData rayCast = {};
+        auto tTOp = _cameraTarget - _cameraPosition;
+        auto tTOpvec = XMLoadFloat3(&tTOp);
+        tTOpvec = XMVector3Normalize(tTOpvec);
+        XMStoreFloat3(&tTOp, -tTOpvec);
+        rayCast.start = _cameraPosition;
+        rayCast.dir = tTOp ;
+
+        Model::RayCast(itr, &rayCast);
         rayCastDir = rayCast.hit && rayCast.dist > .0f && rayCast.dist < rayCastDir ?
             rayCastDir = rayCast.dist : rayCastDir;
+
+        if (rayCast.hit)
+        {
+            ImGui::Text(std::format("{}",rayCast.dist).c_str());
+        }
     }
 
     center = pTarget_->GetPosition();
@@ -230,7 +235,7 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
 
         // 原点からの位置を求めて、カメラの焦点を設定
         XMVECTOR origin_To_camTarget = XMLoadFloat3(&center) + center_To_camTarget;
-        XMStoreFloat3(&_camaraTarget, origin_To_camTarget);
+        XMStoreFloat3(&_cameraTarget, origin_To_camTarget);
 
         // center_To_camTargetの逆ベクトルを用意
         XMVECTOR center_To_camPosition = -center_To_camTarget;
@@ -246,7 +251,7 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
     // ｘ軸の回転を行う
     {
         // 中心を移動
-        XMVECTOR newCenter = (XMLoadFloat3(&_cameraPosition) + XMLoadFloat3(&_camaraTarget)) * ROTATE_Y;
+        XMVECTOR newCenter = (XMLoadFloat3(&_cameraPosition) + XMLoadFloat3(&_cameraTarget)) * ROTATE_Y;
         XMFLOAT3 prevCenter = center;
         XMStoreFloat3(&center, newCenter);
 
@@ -259,10 +264,10 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
         XMMATRIX rotateAxis = XMMatrixRotationAxis(axis, XMConvertToRadians(angle_.x));
 
         //　焦点を設定 
-        XMVECTOR newCenter_To_camTarget = XMLoadFloat3(&_camaraTarget) - XMLoadFloat3(&center);
+        XMVECTOR newCenter_To_camTarget = XMLoadFloat3(&_cameraTarget) - XMLoadFloat3(&center);
         newCenter_To_camTarget = XMVector3Transform(newCenter_To_camTarget, rotateAxis);
         XMVECTOR origin_To_camTarget = XMLoadFloat3(&center) + newCenter_To_camTarget;
-        XMStoreFloat3(&_camaraTarget, origin_To_camTarget);
+        XMStoreFloat3(&_cameraTarget, origin_To_camTarget);
 
         // 位置を設定
         XMVECTOR newCenter_To_camPosition = -newCenter_To_camTarget;

--- a/Game/Objects/Camera/TPSCamera.cpp
+++ b/Game/Objects/Camera/TPSCamera.cpp
@@ -124,11 +124,11 @@ void TPSCamera::CalcRotateAngle(XMFLOAT3 _mouseMove, XMFLOAT3 _padMove)
 
 void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3& _camaraTarget)
 {
-    // 回転の中心を設定１⃣
+    // 回転の中心を設定
     XMFLOAT3 center = pTarget_->GetPosition();
     center.y += targetHeight_;
 
-    // ｙ軸の回転を行うs
+    // y軸の回転を行う
     {
         // 回転行列を作成
         XMMATRIX rotateY = XMMatrixRotationY(XMConvertToRadians(angle_.y));

--- a/Game/Objects/Camera/TPSCamera.cpp
+++ b/Game/Objects/Camera/TPSCamera.cpp
@@ -4,7 +4,8 @@
 #include "../Stage/Stage.h"
 #include "../Stage/StageObject.h"
 #include "TPSCamera.h"
-
+#include"../../../Engine/ResourceManager/Model.h"
+#include"../../../Engine/Global.h"
 
 namespace {
     const float DEFAULT_SENSITIVITY = 15.f;     // 規定感度
@@ -107,6 +108,16 @@ void TPSCamera::DrawData()
     targetName_ = objNames[select];
 }
 
+void TPSCamera::SetRayCastList(std::list<int> list)
+{
+    this->hModels_ = list;
+}
+
+std::list<int> TPSCamera::GetRayCastList()
+{
+    return this->hModels_;
+}
+
 void TPSCamera::CalcRotateAngle(XMFLOAT3 _mouseMove, XMFLOAT3 _padMove)
 {
     // マウスの移動量を元に回転角度を加算
@@ -168,6 +179,82 @@ void TPSCamera::CalcCameraPositionAndTarget(XMFLOAT3& _cameraPosition, XMFLOAT3&
 
         if (XMVector3Equal(axis, XMVectorZero())) axis = prevAxis_;
         
+        //// 回転行列を作成
+        XMMATRIX rotateAxis = XMMatrixRotationAxis(axis, XMConvertToRadians(angle_.x));
+
+        //　焦点を設定 
+        XMVECTOR newCenter_To_camTarget = XMLoadFloat3(&_camaraTarget) - XMLoadFloat3(&center);
+        newCenter_To_camTarget = XMVector3Transform(newCenter_To_camTarget, rotateAxis);
+        XMVECTOR origin_To_camTarget = XMLoadFloat3(&center) + newCenter_To_camTarget;
+        XMStoreFloat3(&_camaraTarget, origin_To_camTarget);
+
+        // 位置を設定
+        XMVECTOR newCenter_To_camPosition = -newCenter_To_camTarget;
+        XMVECTOR origin_To_camPosition = XMLoadFloat3(&center) + newCenter_To_camPosition;
+        XMStoreFloat3(&_cameraPosition, origin_To_camPosition);
+
+    }
+
+    float rayCastDir = targetDistance_;;
+
+    RayCastData rayCast = {};
+    {
+        auto tTOp = _cameraPosition- _camaraTarget  ;
+        auto tTOpvec = XMLoadFloat3(&tTOp);
+        XMStoreFloat3(&rayCast.dir, XMVector3Normalize(tTOpvec));
+        rayCast.start = _camaraTarget;
+    }
+
+    for (auto itr : hModels_) {
+        Model::RayCast(itr, &rayCast);
+
+        rayCastDir = rayCast.hit && rayCast.dist > .0f && rayCast.dist < rayCastDir ?
+            rayCastDir = rayCast.dist : rayCastDir;
+    }
+
+    center = pTarget_->GetPosition();
+    center.y += targetHeight_;
+
+    // y軸の回転を行う
+    {
+        // 回転行列を作成
+        XMMATRIX rotateY = XMMatrixRotationY(XMConvertToRadians(angle_.y));
+
+        // ↑の行列を元に回転
+        XMVECTOR center_To_camTarget = INITIALIZE_AXIS_Z;
+        center_To_camTarget = XMVector3Transform(center_To_camTarget, rotateY);
+
+        // 長さを加える
+        float center_To_camTargetDistance = rayCastDir;
+        center_To_camTarget *= center_To_camTargetDistance;
+
+        // 原点からの位置を求めて、カメラの焦点を設定
+        XMVECTOR origin_To_camTarget = XMLoadFloat3(&center) + center_To_camTarget;
+        XMStoreFloat3(&_camaraTarget, origin_To_camTarget);
+
+        // center_To_camTargetの逆ベクトルを用意
+        XMVECTOR center_To_camPosition = -center_To_camTarget;
+
+        // ちょっと回転させる
+        center_To_camPosition = XMVector3Transform(center_To_camPosition, XMMatrixRotationY(XMConvertToRadians(-ROTATE_LITTLE_ANGLE)));
+
+        // 原点からの位置を求めて、カメラの位置を設定
+        XMVECTOR origin_To_camPosition = XMLoadFloat3(&center) + center_To_camPosition;
+        XMStoreFloat3(&_cameraPosition, origin_To_camPosition);
+    }
+
+    // ｘ軸の回転を行う
+    {
+        // 中心を移動
+        XMVECTOR newCenter = (XMLoadFloat3(&_cameraPosition) + XMLoadFloat3(&_camaraTarget)) * ROTATE_Y;
+        XMFLOAT3 prevCenter = center;
+        XMStoreFloat3(&center, newCenter);
+
+        // 縦回転の軸を作成
+        XMVECTOR axis = XMLoadFloat3(&center) - XMLoadFloat3(&prevCenter);
+
+        if (XMVector3Equal(axis, XMVectorZero())) axis = prevAxis_;
+
         //// 回転行列を作成
         XMMATRIX rotateAxis = XMMatrixRotationAxis(axis, XMConvertToRadians(angle_.x));
 

--- a/Game/Objects/Camera/TPSCamera.h
+++ b/Game/Objects/Camera/TPSCamera.h
@@ -13,6 +13,7 @@ private:
 	float targetHeight_;	// カメラの高さ
 	float targetDistance_;	// カメラの距離
 	XMVECTOR prevAxis_;		// 前回の軸
+	std::list<int> hModels_;
 
 public:
 	/// <summary> コンストラクタ </summary>
@@ -62,6 +63,7 @@ setter :*/
 	/// <summary> 回転角度の設定 </summary>
 	void SetAngle(XMFLOAT2 angle) { angle_ = angle; }
 
+	void SetRayCastList(std::list<int> list);
 /*
 getter :*/
 	/// <summary> カメラの感度の取得 </summary>
@@ -82,6 +84,7 @@ getter :*/
 	/// <summary> 回転角度の取得 </summary>
 	XMFLOAT2 GetAngle() const { return angle_; }
 
+	std::list<int> GetRayCastList();
 /*
 predicate :*/
 	/// <summary> カメラが有効かどうか </summary>

--- a/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
+++ b/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
@@ -963,31 +963,21 @@ void Component_PlayerBehavior::AdjustCameraDistance()
 	Stage* pStage = (Stage*)(holder_->FindObject("Stage"));
 	if (pStage == nullptr) return;
 	std::vector<StageObject*> stageObj = pStage->GetStageObjects();
+	std::list<int> forRaycastModels = {};
+
 	for (auto obj : stageObj) {
-		
+
 		// タイプがNONE以外だったらスキップ
-		if (obj->GetObjectType() != StageObject::TYPE_NONE )
+		if (obj->GetObjectType() != StageObject::TYPE_NONE)
 			continue;
 
 		int hGroundModel = obj->GetModelHandle();
 		if (hGroundModel < 0) continue;
 
-		auto tgt = cam->GetTarget()->GetPosition();
-		RayCastData rayData;
-		{
-			XMStoreFloat3(&rayData.dir, XMVector3Normalize(-Camera::GetSightLine()));
-			rayData.start = Camera::GetTarget(); // レイの発射位置
-			Model::RayCast(hGroundModel, &rayData); // レイを発射
-		}
-
-		distance = rayData.hit && (rayData.dist <= distance) && (rayData.dist > .0) ? rayData.dist : distance;
+		forRaycastModels.push_back(obj->GetModelHandle());
 	}
-	
-	ImGui::Text(std::format("CAM : {},{},{}\nPLY : {},{},{}",
-		Camera::GetTarget().x, Camera::GetTarget().y, Camera::GetTarget().z,
-		holder_->GetPosition().x, holder_->GetPosition().y, holder_->GetPosition().z).c_str());
 
-	cam->SetTargetDistance(distance);
+	cam->SetRayCastList(forRaycastModels);
 }
 
 int Component_PlayerBehavior::GetResearchPointByRarity(PlantData _plantData)

--- a/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
+++ b/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
@@ -959,31 +959,34 @@ void Component_PlayerBehavior::AdjustCameraDistance()
 	TPSCamera* cam = (TPSCamera*)holder_->FindObject("TPSCamera");
 
 	float distance = 3;
-	
+
 	Stage* pStage = (Stage*)(holder_->FindObject("Stage"));
 	if (pStage == nullptr) return;
 	std::vector<StageObject*> stageObj = pStage->GetStageObjects();
 	for (auto obj : stageObj) {
-		// 自分自身のオブジェクトだったらスキップ
-		auto str =obj->GetObjectName();
-		if (obj->GetObjectName() == holder_->GetObjectName() || !obj->GetIsColliding())
+		
+		// タイプがNONE以外だったらスキップ
+		if (obj->GetObjectType() != StageObject::TYPE_NONE )
 			continue;
 
-		// モデルハンドルを取得
 		int hGroundModel = obj->GetModelHandle();
 		if (hGroundModel < 0) continue;
 
 		auto tgt = cam->GetTarget()->GetPosition();
-		// 正面方向にレイを発射
 		RayCastData rayData;
 		{
-			XMStoreFloat3(&rayData.dir, XMVector3Normalize(Camera::GetSightLine()));
-			rayData.start = cam->GetPosition(); // レイの発射位置
+			XMStoreFloat3(&rayData.dir, XMVector3Normalize(-Camera::GetSightLine()));
+			rayData.start = Camera::GetTarget(); // レイの発射位置
 			Model::RayCast(hGroundModel, &rayData); // レイを発射
 		}
 
 		distance = rayData.hit && (rayData.dist <= distance) && (rayData.dist > .0) ? rayData.dist : distance;
 	}
+	
+	ImGui::Text(std::format("CAM : {},{},{}\nPLY : {},{},{}",
+		Camera::GetTarget().x, Camera::GetTarget().y, Camera::GetTarget().z,
+		holder_->GetPosition().x, holder_->GetPosition().y, holder_->GetPosition().z).c_str());
+
 	cam->SetTargetDistance(distance);
 }
 

--- a/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
+++ b/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.cpp
@@ -278,6 +278,7 @@ void Component_PlayerBehavior::Update()
 	lockRotateFrameLeft_ = NULL;
 	lockRotateFrame_ = NULL;
 
+	AdjustCameraDistance();
 }
 
 void Component_PlayerBehavior::Release()
@@ -334,6 +335,7 @@ void Component_PlayerBehavior::Idle()
 	// 状態優先度：歩行 > 射撃
 	// `InputMove`コンポーネントの移動フラグが立っていたら...歩行状態に遷移
 	if (move->IsMove()) SetState(PLAYER_STATE_WALK);
+	
 
 	// マウスの左ボタンが押されていたまたは、マウスの左ボタンが押されてたら、射撃状態に遷移
 	else if (Input::IsMouseButtonDown(0) || Input::IsPadTriggerDownR(0)) {
@@ -950,6 +952,39 @@ void Component_PlayerBehavior::DrawPopUp()
 	else FallPopUp();
 
 	--popUpInfo_.time;
+}
+
+void Component_PlayerBehavior::AdjustCameraDistance()
+{
+	TPSCamera* cam = (TPSCamera*)holder_->FindObject("TPSCamera");
+
+	float distance = 3;
+	
+	Stage* pStage = (Stage*)(holder_->FindObject("Stage"));
+	if (pStage == nullptr) return;
+	std::vector<StageObject*> stageObj = pStage->GetStageObjects();
+	for (auto obj : stageObj) {
+		// 自分自身のオブジェクトだったらスキップ
+		auto str =obj->GetObjectName();
+		if (obj->GetObjectName() == holder_->GetObjectName() || !obj->GetIsColliding())
+			continue;
+
+		// モデルハンドルを取得
+		int hGroundModel = obj->GetModelHandle();
+		if (hGroundModel < 0) continue;
+
+		auto tgt = cam->GetTarget()->GetPosition();
+		// 正面方向にレイを発射
+		RayCastData rayData;
+		{
+			XMStoreFloat3(&rayData.dir, XMVector3Normalize(Camera::GetSightLine()));
+			rayData.start = cam->GetPosition(); // レイの発射位置
+			Model::RayCast(hGroundModel, &rayData); // レイを発射
+		}
+
+		distance = rayData.hit && (rayData.dist <= distance) && (rayData.dist > .0) ? rayData.dist : distance;
+	}
+	cam->SetTargetDistance(distance);
 }
 
 int Component_PlayerBehavior::GetResearchPointByRarity(PlantData _plantData)

--- a/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.h
+++ b/Game/Objects/Stage/Components/BehaviorComponents/Component_PlayerBehavior.h
@@ -219,4 +219,6 @@ private:
 	void ResetSaladEffectLogo();
 
 	void DrawPopUp();
+
+	void AdjustCameraDistance();
 };


### PR DESCRIPTION
・レイキャストするオブジェクトの選別をPlayerBehavior内で行う AdjustCaneraDistance()
・TPSCameraにレイキャストするモデルのセッターゲッター、及びコンテナの追加
・変数名の修正　camara -> camera
・現在計算を二重にやるおバカソースコードだが、計算が複雑かつ制作者からの解説が絶望的なためコストを妥協せざるを得ない